### PR TITLE
Set Spring Boot version to 2.1.x as start.spring.io now defaults to 2…

### DIFF
--- a/scripts/00-create-projects.sh
+++ b/scripts/00-create-projects.sh
@@ -8,7 +8,7 @@ fi
 
 pushd ${CONTRACT_DEMO_HOME}
 
-curl https://start.spring.io/starter.tgz -d name=simple-producer -d artifactId=simple-producer -d dependencies=web,cloud-contract-verifier -d baseDir=simple-producer | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d name=simple-producer -d artifactId=simple-producer -d dependencies=web,cloud-contract-verifier -d baseDir=simple-producer -d bootVersion=2.1.7.RELEASE  | tar -xzvf -
 echo "" >> simple-producer/.gitignore
 echo ".DS_Store" >> simple-producer/.gitignore
 echo "# simple-producer" >> simple-producer/README.md
@@ -16,7 +16,7 @@ echo "# simple-producer" >> simple-producer/README.md
 
 # Use Spring Initializr to create consumer app
 
-curl https://start.spring.io/starter.tgz -d name=simple-consumer -d artifactId=simple-consumer -d dependencies=web,cloud-contract-stub-runner -d baseDir=simple-consumer | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d name=simple-consumer -d artifactId=simple-consumer -d dependencies=web,cloud-contract-stub-runner -d baseDir=simple-consumer -d bootVersion=2.1.7.RELEASE | tar -xzvf -
 echo "" >> simple-consumer/.gitignore
 echo ".DS_Store" >> simple-consumer/.gitignore
 echo "# simple-consumer" >> simple-consumer/README.md


### PR DESCRIPTION
….2.x and this demo breaks with 2.2.x as the various steps that "patch" code to implement contract testing all need to be updated to 2.2.x and a compatible version of JUnit 5 dependencies. The right "fix" is to update the "patch" code to work with Boot 2.2.x + JUnit 5. This is a stopgap fix.